### PR TITLE
Filename setting/formatting

### DIFF
--- a/bin/fontello-svg.js
+++ b/bin/fontello-svg.js
@@ -37,6 +37,7 @@ app.option('-c, --config <config file>', 'Set the Fontello configuration file (r
 app.option('-o, --out <dir>', 'Set the export directory (required)');
 app.option('-f, --fill-colors <colors>', 'Transform the SVG paths to the specified colors. Syntax: --fill-colors "black:rgb(0,0,0) | red:rgb(255,0,0)"', argsObject);
 app.option('-p, --css-path <path>', 'Set a CSS path for SVG backgrounds');
+app.option('--file-format <format>', 'Override the default filename. Values: {0} - collection, {1} - name, {2} - color. Syntax: "{0}-{1}-{2}.svg" | "{0}-Custom-{1}.svg" "');
 app.option('--no-css', 'Do not create the CSS file');
 app.option('--no-skip', 'Do not skip existing files');
 app.option('--verbose', 'Verbose output');
@@ -57,6 +58,7 @@ var config = require(path.resolve(app.config));
 var out = path.resolve(app.out);
 var colors = app.fillColors || {'black': '#000000'};
 var backgroundUrlPath = app.cssPath || '';
+var fileFormat = app.fileFormat || "{0}-{1}-{2}.svg";
 
 start(config.glyphs, out, colors, app);
 
@@ -65,7 +67,7 @@ function relativePath(abspath) {
 }
 
 function start(rawGlyphs, out, colors, app) {
-  var glyphs = fontelloSvg.allGlyphs(rawGlyphs, colors);
+  var glyphs = fontelloSvg.allGlyphs(rawGlyphs, colors, fileFormat);
 
   if (!fs.existsSync(out)){
     fs.mkdirSync(out);

--- a/bin/fontello-svg.js
+++ b/bin/fontello-svg.js
@@ -5,6 +5,7 @@ var _ = require('underscore');
 var path = require('path');
 var app = require('commander');
 var colors = require('colors');
+var fs = require('fs');
 
 function l(msg, indent, nlBefore, nlAfter) {
   if (!indent) indent = 0;
@@ -65,6 +66,10 @@ function relativePath(abspath) {
 
 function start(rawGlyphs, out, colors, app) {
   var glyphs = fontelloSvg.allGlyphs(rawGlyphs, colors);
+
+  if (!fs.existsSync(out)){
+    fs.mkdirSync(out);
+  }
 
   if (app.skip) {
     fontelloSvg.missingGlyphs(glyphs, out, processGlyphs);

--- a/index.js
+++ b/index.js
@@ -30,11 +30,23 @@ function svgUrl(name, collection) {
          '/master/src/svg/' + name + '.svg';
 }
 
+if (!String.format) {
+  String.format = function(format) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    return String(format.replace(/{(\d+)}/g, function(match, number) { 
+      return typeof args[number] != 'undefined'
+        ? args[number] 
+        : match
+      ;
+    }));
+  };
+}
+
 // The Glyph object
 var Glyph = {
   filename: function(color) {
     color = this.validColor(color);
-    return this.collection + '-' + this.name + '-' + color + '.svg';
+    return String.format(this.fileFormat, this.collection, this.name, color);
   },
   filenames: function() {
     return Object.keys(this.colors).map(function(color) {
@@ -62,9 +74,10 @@ var Glyph = {
 };
 
 // Creates and returns a Glyph instance
-function createGlyph(name, collection, id, colors) {
+function createGlyph(name, collection, id, colors, fileFormat) {
   var glyph = Object.create(Glyph);
   if (!colors) colors = { 'black': 'rgb(0,0,0)' };
+  if (!fileFormat) fileFormat = "{0}-{1}-{2}.svg";
   if (!id) id = name;
   glyph.id = id;
   glyph.name = name;
@@ -72,6 +85,7 @@ function createGlyph(name, collection, id, colors) {
   glyph.url = svgUrl(glyph.name, glyph.collection);
   glyph.colors = colors;
   glyph.exists = null;
+  glyph.fileFormat = fileFormat;
   return glyph;
 }
 
@@ -107,13 +121,13 @@ function fixNames(rawGlyphs) {
 }
 
 // Creates and returns all Glyphs from a rawGlyphs list
-function allGlyphs(rawGlyphs, colors) {
+function allGlyphs(rawGlyphs, colors, fileFormat) {
   var unique = nodupes();
   rawGlyphs = fixNames(rawGlyphs);
   return rawGlyphs.map(function(rawGlyph) {
     var name = rawGlyph.css;
     var collection = rawGlyph.src;
-    return createGlyph(name, collection, unique(name), colors);
+    return createGlyph(name, collection, unique(name), colors, fileFormat);
   });
 }
 


### PR DESCRIPTION
Hey, i needed to remove the -black from the filenames when they get saved - e.g.

fontawesome-search-black.svg to 
fontawesome-search.svg

I've added in a flag to allow the setting of the format which allows complete customization but also defaults to what it currently was.

You set with --file-format {0}-{1}-{2}.svg

Where {0} is the collection
{1} is the name
{2} is the color

So now i can rewrite my format as {0}-{1}.svg which removes the color.

This pull request also has the previous feature aswell which adds the folder if it doesn't already exist.